### PR TITLE
make sure stdout is really JSON

### DIFF
--- a/bin/ssh-add
+++ b/bin/ssh-add
@@ -35,7 +35,7 @@ function addKey(err, keys) {
       if (!data.type) { return; }
 
       if (data.type === 'addKeyResponse') {
-        console.log(data);
+        console.log(JSON.stringify(data));
         process.exit(0);
       }
     });

--- a/bin/ssh-list
+++ b/bin/ssh-list
@@ -17,7 +17,7 @@ client({path: path}, function (err, stream) {
     if (!data.type) { return; }
 
     if (data.type === 'listKeysResponse') {
-      console.log(data.keys);
+      console.log(JSON.stringify(data.keys));
       process.exit(0);
     }
   });

--- a/bin/ssh-sign
+++ b/bin/ssh-sign
@@ -44,7 +44,7 @@ function sign(err, stringToSign) {
       if (!data.type) { return; }
 
       if (data.type === 'signResponse') {
-        console.log(data.signature);
+        console.log(JSON.stringify(data.signature));
         process.exit(1);
       }
     });

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var events = [
 
 fs.unlink(cfg.path, function () {
   // TODO: permissions on socket?
-  server = require('./server')({}, events);
+  var server = require('./server')({}, events);
   server.listen(cfg.path, function() {
     console.log('listening on path ' + cfg.path);
   });


### PR DESCRIPTION
This is to enable applications running it wanting to do `JSON.parse()` on the output. This will fail if e.g. `node-ssh-list` returns [ 'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx' ] which is not valid JSON due to `'`.

cc @dweinstein 
